### PR TITLE
Remove mandatory empty slot filler

### DIFF
--- a/src/main/java/me/ampayne2/ampmenus/menus/ItemMenu.java
+++ b/src/main/java/me/ampayne2/ampmenus/menus/ItemMenu.java
@@ -21,8 +21,6 @@ package me.ampayne2.ampmenus.menus;
 import me.ampayne2.ampmenus.events.ItemClickEvent;
 import me.ampayne2.ampmenus.items.MenuItem;
 import org.bukkit.Bukkit;
-import org.bukkit.DyeColor;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -31,8 +29,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**


### PR DESCRIPTION
This commit removes the forced ItemMenu behavior of adding gray stained glass panes to the unused slots. It's really just nitpicking, but feel free to merge if you agree.
