### PR TITLE
Fixed menu updating if item is removed

### DIFF
--- a/src/main/java/ninja/amp/ampmenus/menus/ItemMenu.java
+++ b/src/main/java/ninja/amp/ampmenus/menus/ItemMenu.java
@@ -196,6 +196,8 @@ public class ItemMenu {
         for (int i = 0; i < items.length; i++) {
             if (items[i] != null) {
                 inventory.setItem(i, items[i].getFinalIcon(player));
+            } else {
+                inventory.setItem(i, new ItemStack(Material.AIR));
             }
         }
     }


### PR DESCRIPTION
If you previously removed an item / cleared the menu and then updated it, the item has not been removed from the inventory. Now it removes the empty slots.